### PR TITLE
Fix IK toggle after adding rotation limits

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -749,15 +749,15 @@ class NullObjectAnimator extends BoneAnimator {
 
 		if (get_samples) return results;
 	}
-	displayFrame(multiplier = 1) {
-		if (!this.doRender()) return;
-		this.getElement()
+        displayFrame(multiplier = 1) {
+               if (!this.doRender()) return;
+               const null_object = this.getElement();
 
                if (!this.muted.position) {
                        this.displayPosition(this.interpolate('position'), multiplier);
-                       if (this.group && this.group.ik_enabled) this.displayIK();
+                       if (null_object?.ik_target) this.displayIK();
                }
-	}
+       }
 }
 	NullObjectAnimator.prototype.type = 'null_object';
 	NullObjectAnimator.prototype.channels = {


### PR DESCRIPTION
## Summary
- Ensure NullObject animator calls inverse kinematics based on IK target rather than group state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run bundle`


------
https://chatgpt.com/codex/tasks/task_b_689ceb9060a4832bad7d5ddea668f834