### PR TITLE
Iterate IK solving with constraint clamping

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -642,7 +642,7 @@ class NullObjectAnimator extends BoneAnimator {
 
 		let bones = [];
 		let ik_target = new THREE.Vector3().copy(null_object.getWorldCenter(true));
-		let bone_references = [];
+               let bone_references = [];
 		let current = target.parent;
 
 		let source;
@@ -665,112 +665,125 @@ class NullObjectAnimator extends BoneAnimator {
                        bones.push(source);
                }
 		if (!bones.length) return;
-		bones.reverse();
-		
+               bones.reverse();
+
                let base_rotations = {};
                bones.forEach(bone => {
                        if (bone.mesh.fix_rotation) bone.mesh.rotation.copy(bone.mesh.fix_rotation);
                        base_rotations[bone.uuid] = bone.mesh.rotation.clone();
                })
 
-              bones.forEach((bone, i) => {
-                        let startPoint = new FIK.V3(0,0,0).copy(bone.mesh.getWorldPosition(new THREE.Vector3()));
-                        let endPoint = new FIK.V3(0,0,0).copy(bones[i+1] ? bones[i+1].mesh.getWorldPosition(new THREE.Vector3()) : null_object.getWorldCenter(false));
-
-                        let ik_bone = new FIK.Bone3D(startPoint, endPoint);
-                        this.chain.addBone(ik_bone);
-
-			bone_references.push({
-				bone,
-				last_diff: new THREE.Vector3(
-					(bones[i+1] ? bones[i+1] : target).origin[0] - bone.origin[0],
-					(bones[i+1] ? bones[i+1] : target).origin[1] - bone.origin[1],
-					(bones[i+1] ? bones[i+1] : target).origin[2] - bone.origin[2]
-				).normalize()
-                        })
-                })
-                // Lower the distance threshold so the solver continues bending
-                // the chain even when the IK target is very close to the limb.
-                this.chain.solveDistanceThreshold = 0;
-
-                this.solver.add(this.chain, ik_target , true);
-                this.solver.meshChains[0].forEach(mesh => {
-                        mesh.visible = false;
-                })
+               bone_references = bones.map((bone, i) => ({
+                       bone,
+                       last_diff: new THREE.Vector3(
+                               (bones[i+1] ? bones[i+1] : target).origin[0] - bone.origin[0],
+                               (bones[i+1] ? bones[i+1] : target).origin[1] - bone.origin[1],
+                               (bones[i+1] ? bones[i+1] : target).origin[2] - bone.origin[2]
+                       ).normalize()
+               }))
 
                if (target_original_quaternion) {
                        base_rotations[target.uuid] = target.mesh.rotation.clone();
                }
 
-               this.solver.update();
+               const max_iterations = 5;
+               const epsilon = 1e-3;
+               for (let iteration = 0; iteration < max_iterations; iteration++) {
 
-               bone_references.forEach((bone_ref, i) => {
-                       let start = Reusable.vec1.copy(this.solver.chains[0].bones[i].start);
-                       let end = Reusable.vec2.copy(this.solver.chains[0].bones[i].end);
-                       bones[i].mesh.worldToLocal(start);
-                       bones[i].mesh.worldToLocal(end);
+                       this.chain.clear();
+                       bones.forEach((bone, i) => {
+                               let startPoint = new FIK.V3(0,0,0).copy(bone.mesh.getWorldPosition(new THREE.Vector3()));
+                               let endPoint = new FIK.V3(0,0,0).copy(bones[i+1] ? bones[i+1].mesh.getWorldPosition(new THREE.Vector3()) : null_object.getWorldCenter(false));
 
-                       Reusable.quat1.setFromUnitVectors(bone_ref.last_diff, end.sub(start).normalize());
-                       let rotation = Reusable.euler1;
-                       rotation.setFromQuaternion(Reusable.quat1, 'ZYX');
+                               let ik_bone = new FIK.Bone3D(startPoint, endPoint);
+                               this.chain.addBone(ik_bone);
+                       })
+                       // Lower the distance threshold so the solver continues bending
+                       // the chain even when the IK target is very close to the limb.
+                       this.chain.solveDistanceThreshold = 0;
+                       this.chain.lastTargetLocation.set(1e9, 0, 0);
 
-                      bone_ref.bone.mesh.rotation.x += rotation.x;
-                      bone_ref.bone.mesh.rotation.y += rotation.y;
-                      bone_ref.bone.mesh.rotation.z += rotation.z;
+                       this.solver.clear();
+                       this.solver.add(this.chain, ik_target , true);
+                       this.solver.meshChains[0].forEach(mesh => {
+                               mesh.visible = false;
+                       })
 
-                       Reusable.euler2.copy(bone_ref.bone.mesh.rotation);
-                      this.clampRotation(bone_ref.bone);
-                      bone_ref.bone.mesh.updateMatrixWorld();
-                       Reusable.vec3.set(
-                               Reusable.euler2.x - bone_ref.bone.mesh.rotation.x,
-                               Reusable.euler2.y - bone_ref.bone.mesh.rotation.y,
-                               Reusable.euler2.z - bone_ref.bone.mesh.rotation.z
-                       );
-                       if (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5) {
-                               for (let j = i - 1; j >= 0 && (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5); j--) {
-                                       let parent = bone_references[j].bone;
-                                       Reusable.euler2.copy(parent.mesh.rotation);
-                                       const share = j + 1;
-                                       parent.mesh.rotation.x += Reusable.vec3.x / share;
-                                       parent.mesh.rotation.y += Reusable.vec3.y / share;
-                                       parent.mesh.rotation.z += Reusable.vec3.z / share;
-                                       this.clampRotation(parent);
-                                       parent.mesh.updateMatrixWorld();
-                                       Reusable.vec3.x -= parent.mesh.rotation.x - Reusable.euler2.x;
-                                       Reusable.vec3.y -= parent.mesh.rotation.y - Reusable.euler2.y;
-                                       Reusable.vec3.z -= parent.mesh.rotation.z - Reusable.euler2.z;
+                       this.solver.update();
+
+                       bone_references.forEach((bone_ref, i) => {
+                               let start = Reusable.vec1.copy(this.solver.chains[0].bones[i].start);
+                               let end = Reusable.vec2.copy(this.solver.chains[0].bones[i].end);
+                               bones[i].mesh.worldToLocal(start);
+                               bones[i].mesh.worldToLocal(end);
+
+                               Reusable.quat1.setFromUnitVectors(bone_ref.last_diff, end.sub(start).normalize());
+                               let rotation = Reusable.euler1;
+                               rotation.setFromQuaternion(Reusable.quat1, 'ZYX');
+
+                               bone_ref.bone.mesh.rotation.x += rotation.x;
+                               bone_ref.bone.mesh.rotation.y += rotation.y;
+                               bone_ref.bone.mesh.rotation.z += rotation.z;
+
+                               Reusable.euler2.copy(bone_ref.bone.mesh.rotation);
+                               this.clampRotation(bone_ref.bone);
+                               bone_ref.bone.mesh.updateMatrixWorld();
+                               Reusable.vec3.set(
+                                       Reusable.euler2.x - bone_ref.bone.mesh.rotation.x,
+                                       Reusable.euler2.y - bone_ref.bone.mesh.rotation.y,
+                                       Reusable.euler2.z - bone_ref.bone.mesh.rotation.z
+                               );
+                               if (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5) {
+                                       for (let j = i - 1; j >= 0 && (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5); j--) {
+                                               let parent = bone_references[j].bone;
+                                               Reusable.euler2.copy(parent.mesh.rotation);
+                                               const share = j + 1;
+                                               parent.mesh.rotation.x += Reusable.vec3.x / share;
+                                               parent.mesh.rotation.y += Reusable.vec3.y / share;
+                                               parent.mesh.rotation.z += Reusable.vec3.z / share;
+                                               this.clampRotation(parent);
+                                               parent.mesh.updateMatrixWorld();
+                                               Reusable.vec3.x -= parent.mesh.rotation.x - Reusable.euler2.x;
+                                               Reusable.vec3.y -= parent.mesh.rotation.y - Reusable.euler2.y;
+                                               Reusable.vec3.z -= parent.mesh.rotation.z - Reusable.euler2.z;
+                                       }
+                               }
+                       })
+
+                       if (target_original_quaternion) {
+                               Reusable.euler2.copy(target.mesh.rotation);
+
+                               target.mesh.quaternion.copy(target_original_quaternion);
+                               let q1 = target.mesh.parent.getWorldQuaternion(Reusable.quat1);
+                               target.mesh.quaternion.premultiply(q1.invert())
+                               this.clampRotation(target);
+                               target.mesh.updateMatrixWorld();
+
+                               Reusable.vec3.set(
+                                       Reusable.euler2.x - target.mesh.rotation.x,
+                                       Reusable.euler2.y - target.mesh.rotation.y,
+                                       Reusable.euler2.z - target.mesh.rotation.z
+                               );
+                               if (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5) {
+                                       for (let j = bone_references.length - 1; j >= 0 && (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5); j--) {
+                                               let parent = bone_references[j].bone;
+                                               Reusable.euler2.copy(parent.mesh.rotation);
+                                               const share = j + 1;
+                                               parent.mesh.rotation.x += Reusable.vec3.x / share;
+                                               parent.mesh.rotation.y += Reusable.vec3.y / share;
+                                               parent.mesh.rotation.z += Reusable.vec3.z / share;
+                                               this.clampRotation(parent);
+                                               parent.mesh.updateMatrixWorld();
+                                               Reusable.vec3.x -= parent.mesh.rotation.x - Reusable.euler2.x;
+                                               Reusable.vec3.y -= parent.mesh.rotation.y - Reusable.euler2.y;
+                                               Reusable.vec3.z -= parent.mesh.rotation.z - Reusable.euler2.z;
+                                       }
                                }
                        }
-               })
 
-               if (target_original_quaternion) {
-                       Reusable.euler2.copy(target.mesh.rotation);
-
-                      target.mesh.quaternion.copy(target_original_quaternion);
-                      let q1 = target.mesh.parent.getWorldQuaternion(Reusable.quat1);
-                      target.mesh.quaternion.premultiply(q1.invert())
-                      this.clampRotation(target);
-                      target.mesh.updateMatrixWorld();
-
-                       Reusable.vec3.set(
-                               Reusable.euler2.x - target.mesh.rotation.x,
-                               Reusable.euler2.y - target.mesh.rotation.y,
-                               Reusable.euler2.z - target.mesh.rotation.z
-                       );
-                       if (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5) {
-                               for (let j = bone_references.length - 1; j >= 0 && (Math.abs(Reusable.vec3.x) > 1e-5 || Math.abs(Reusable.vec3.y) > 1e-5 || Math.abs(Reusable.vec3.z) > 1e-5); j--) {
-                                       let parent = bone_references[j].bone;
-                                       Reusable.euler2.copy(parent.mesh.rotation);
-                                       const share = j + 1;
-                                       parent.mesh.rotation.x += Reusable.vec3.x / share;
-                                       parent.mesh.rotation.y += Reusable.vec3.y / share;
-                                       parent.mesh.rotation.z += Reusable.vec3.z / share;
-                                       this.clampRotation(parent);
-                                       parent.mesh.updateMatrixWorld();
-                                       Reusable.vec3.x -= parent.mesh.rotation.x - Reusable.euler2.x;
-                                       Reusable.vec3.y -= parent.mesh.rotation.y - Reusable.euler2.y;
-                                       Reusable.vec3.z -= parent.mesh.rotation.z - Reusable.euler2.z;
-                               }
+                       if (target.getWorldCenter) {
+                               let tip = new THREE.Vector3().copy(target.getWorldCenter(true));
+                               if (tip.distanceTo(ik_target) < epsilon) break;
                        }
                }
 


### PR DESCRIPTION
## Summary
- Iterate up to five IK passes, rebuilding the chain from the current pose each time.
- Apply rotations with clamping after each solve and break early when the tip error is below a threshold.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689db477bed0832bad517437a110db4d