### PR TITLE
Add distance metric option to IK cube sweep

### DIFF
--- a/js/animations/ik_test_runner.js
+++ b/js/animations/ik_test_runner.js
@@ -138,19 +138,25 @@
   }
 
   // ---------- NEW: CUBE SWEEP (3D, async & UI-friendly) ----------
-async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps = 11, okEps = 1e-2, onProgress }) {
+async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps = 11, okEps = 1e-2, onProgress, metric = 'err' }) {
   const reach = estimateReach(nullObj);
   const span = reach * halfSpan;
   const N = Math.max(3, steps|0);
 
   const axis = [...Array(N)].map((_,i)=> -span + (2*span)*(i/(N-1)));
   const rows = [];
-  rows.push(['ix','iy','iz','x','y','z','posErr','ok'].join(','));
+  const metricLabel = metric === 'dist' ? 'targetDist' : 'posErr';
+  rows.push(['ix','iy','iz','x','y','z',metricLabel,'ok'].join(','));
 
   let pass = 0, fail = 0;
   const origPos = nullObj.mesh.getWorldPosition(new THREE.Vector3());
   const total = N * N * N;
   let done = 0;
+
+  // cache target for distance metric
+  const targetNode = metric === 'dist'
+    ? ([...Group.all, ...Locator.all].find(n => n.uuid == nullObj.ik_target) || null)
+    : null;
 
   // small helper to keep UI responsive
   const yieldUI = () => new Promise(requestAnimationFrame);
@@ -165,12 +171,22 @@ async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps 
         if ((done & 63) === 0) await yieldUI();
 
         const res = anim.displayIK(true);
-        const m = (res && res.__metrics) || { posErr: Number.POSITIVE_INFINITY };
-        const ok = (m.posErr <= okEps);
+
+        let metricVal;
+        if (metric === 'dist') {
+          const nullPos = nullObj.mesh.getWorldPosition(new THREE.Vector3());
+          const tgtPos = targetNode?.mesh.getWorldPosition(new THREE.Vector3());
+          metricVal = tgtPos ? nullPos.distanceTo(tgtPos) : Number.POSITIVE_INFINITY;
+        } else {
+          const m = (res && res.__metrics) || { posErr: Number.POSITIVE_INFINITY };
+          metricVal = m.posErr;
+        }
+
+        const ok = (metricVal <= okEps);
 
         rows.push([ix,iy,iz,
           p.x.toFixed(6), p.y.toFixed(6), p.z.toFixed(6),
-          m.posErr.toFixed(6), ok ? 1 : 0
+          metricVal.toFixed(6), ok ? 1 : 0
         ].join(','));
 
         if (ok) pass++; else fail++;
@@ -260,12 +276,14 @@ async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps 
       form: {
         steps:  { label: 'Samples per axis (N)', type: 'number', value: 11, min: 5,  max: 41,  step: 2 },
         span:   { label: 'Half-span (% of reach)', type: 'number', value: 60, min: 10, max: 120, step: 5 },
-        eps:    { label: 'OK threshold (ε)', type: 'number', value: 0.01, step: 0.001 }
+        eps:    { label: 'OK threshold (ε)', type: 'number', value: 0.01, step: 0.001 },
+        metric: { label: 'Metric', type: 'select', options: { err: 'Positional error', dist: 'Distance to target' }, value: 'err' }
       },
       async onConfirm(form) {
         const steps = Math.max(5, Math.min(41, parseInt(form.steps)));      // 11 → 1331 samples (fast); 21 → 9261 (heavier)
         const halfSpan = Math.max(0.1, Math.min(1.2, (parseFloat(form.span)||60) / 100));
         const okEps = Math.max(1e-6, parseFloat(form.eps)||1e-2);
+        const metric = form.metric || 'err';
 
         // Precompute sample count so progress text works before sweep resolves
         const N = Math.max(3, steps|0);
@@ -274,7 +292,7 @@ async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps 
         // simple progress nudges (UI stays responsive)
         let lastPct = -1;
         const result = await runCubeSweepAsync({
-          anim, nullObj, center, halfSpan, steps, okEps,
+          anim, nullObj, center, halfSpan, steps, okEps, metric,
           onProgress: (pct) => {
             const p = Math.floor(pct*100);
             if (p !== lastPct) {
@@ -287,7 +305,7 @@ async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps 
 
         const { csv, pass, fail, reach, total } = result;
         const stamp = new Date().toISOString().replace(/[:.]/g, '-');
-        saveCSV(`ik_cube_${stamp}_N${N}_reach${reach.toFixed(3)}.csv`, csv);
+        saveCSV(`ik_cube_${stamp}_N${N}_${metric}_reach${reach.toFixed(3)}.csv`, csv);
         Blockbench.showMessageBox({
           title: 'IK Cube Sweep',
           message: `Pass: ${pass}  •  Fail: ${fail}\nReach≈ ${reach.toFixed(3)}  •  Samples: ${N}×${N}×${N} = ${total}`,


### PR DESCRIPTION
## Summary
- add optional distance-to-target metric for 3D IK cube sweeps
- allow choosing metric in cube sweep dialog and include it in CSV filename

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a59cd110a0832b9da59401ec3eb121