### PR TITLE
Add ball joint constraint support to CCD solver

### DIFF
--- a/ik/src/solvers/ccd2.js
+++ b/ik/src/solvers/ccd2.js
@@ -5,7 +5,7 @@
  *   allowing out-of-plane motion.
  */
 const THREE = require('three');
-const { clampHinge } = require('../math/ik_constraints');
+const { clampHinge, clampBall } = require('../math/ik_constraints');
 
 function wrapAngleIntoLimits(angle, min, max) {
   // Bring 'angle' to an equivalent value (angle + 2πk) that lies inside [min, max] if possible.
@@ -23,10 +23,39 @@ function wrapAngleIntoLimits(angle, min, max) {
 class TwoBoneChain {
   constructor(L1, L2, opts = {}) {
     this.L1 = L1; this.L2 = L2;
-    this.axis0 = (opts.axis0 || new THREE.Vector3(0,0,1)).clone().normalize();
-    this.axis1 = (opts.axis1 || new THREE.Vector3(0,0,1)).clone().normalize();
-    this.lim0 = opts.lim0 || { min: -Math.PI*0.75, max: Math.PI*0.75 }; // shoulder range
-    this.lim1 = opts.lim1 || { min: 0.0, max: Math.PI*0.95 };           // elbow flexion
+
+    function buildConstraint(opt, defAxis, defLim) {
+      if (!opt) opt = {};
+      const type = opt.type || 'hinge';
+      const axis = (opt.axis || defAxis).clone().normalize();
+      if (type === 'ball') {
+        return {
+          type,
+          axis,
+          swingX: opt.swingX || Math.PI,
+          swingY: opt.swingY || Math.PI,
+          twistMin: opt.twistMin != null ? opt.twistMin : -Math.PI,
+          twistMax: opt.twistMax != null ? opt.twistMax : Math.PI
+        };
+      } else {
+        const lim = opt.lim || defLim;
+        return { type, axis, min: lim.min, max: lim.max };
+      }
+    }
+
+    this.joint0 = buildConstraint(opts.joint0 || { axis: opts.axis0, lim: opts.lim0, type: opts.type0 }, new THREE.Vector3(0,0,1), { min: -Math.PI*0.75, max: Math.PI*0.75 });
+    this.joint1 = buildConstraint(opts.joint1 || { axis: opts.axis1, lim: opts.lim1, type: opts.type1 }, new THREE.Vector3(0,0,1), { min: 0.0, max: Math.PI*0.95 });
+
+    this.axis0 = this.joint0.axis.clone();
+    this.axis1 = this.joint1.axis.clone();
+
+    // For warm start we use twist ranges as lim0/lim1 for ball joints
+    this.lim0 = this.joint0.type === 'ball'
+      ? { min: this.joint0.twistMin, max: this.joint0.twistMax }
+      : { min: this.joint0.min, max: this.joint0.max };
+    this.lim1 = this.joint1.type === 'ball'
+      ? { min: this.joint1.twistMin, max: this.joint1.twistMax }
+      : { min: this.joint1.min, max: this.joint1.max };
 
     this.q0 = new THREE.Quaternion(); // local joint rotations
     this.q1 = new THREE.Quaternion();
@@ -90,56 +119,86 @@ class TwoBoneChain {
     this.q1.setFromAxisAngle(this.axis1, phi);
 
     // Final strict clamp (no-op if already inside)
-    this.q0 = clampHinge(this.q0, this.axis0, this.lim0.min, this.lim0.max);
-    this.q1 = clampHinge(this.q1, this.axis1, this.lim1.min, this.lim1.max);
+    if (this.joint0.type === 'ball') {
+      this.q0 = clampBall(this.q0, this.axis0, this.joint0.swingX, this.joint0.swingY, this.joint0.twistMin, this.joint0.twistMax);
+    } else {
+      this.q0 = clampHinge(this.q0, this.axis0, this.lim0.min, this.lim0.max);
+    }
+    if (this.joint1.type === 'ball') {
+      this.q1 = clampBall(this.q1, this.axis1, this.joint1.swingX, this.joint1.swingY, this.joint1.twistMin, this.joint1.twistMax);
+    } else {
+      this.q1 = clampHinge(this.q1, this.axis1, this.lim1.min, this.lim1.max);
+    }
   }
 
-  // Rotate a joint strictly about its hinge axis to align the chain toward target
-  rotateJointAboutHinge(jIndex, target) {
+  // Rotate a joint to align the chain toward target, obeying hinge or ball constraints
+  rotateJoint(jIndex, target) {
     const { p0, p1, p2, q0w, a0w, a1w } = this.fk();
+    const joint = jIndex === 1 ? this.joint1 : this.joint0;
 
-    const parent_qw = (jIndex === 1) ? q0w : new THREE.Quaternion();
-    const jointPos  = (jIndex === 1) ? p1 : p0;
-    const axis_w    = (jIndex === 1) ? a1w.clone() : a0w.clone();
+    const parent_qw = jIndex === 1 ? q0w : new THREE.Quaternion();
+    const jointPos  = jIndex === 1 ? p1 : p0;
 
-    // Current and target vectors from the joint, projected onto hinge plane
     const v_cur = p2.clone().sub(jointPos);
     const v_tar = target.clone().sub(jointPos);
 
-    const v_cur_proj = v_cur.clone().sub(axis_w.clone().multiplyScalar(axis_w.dot(v_cur)));
-    const v_tar_proj = v_tar.clone().sub(axis_w.clone().multiplyScalar(axis_w.dot(v_tar)));
+    const n_cur = v_cur.length();
+    const n_tar = v_tar.length();
+    if (n_cur < 1e-9 || n_tar < 1e-9) return;
 
-    const n_cur = v_cur_proj.length();
-    const n_tar = v_tar_proj.length();
-    if (n_cur < 1e-9 || n_tar < 1e-9) return; // degenerate
+    let delta_world;
+    if (joint.type === 'hinge') {
+      const axis_w = jIndex === 1 ? a1w.clone() : a0w.clone();
+      const v_cur_proj = v_cur.clone().sub(axis_w.clone().multiplyScalar(axis_w.dot(v_cur)));
+      const v_tar_proj = v_tar.clone().sub(axis_w.clone().multiplyScalar(axis_w.dot(v_tar)));
 
-    // Signed angle around hinge axis
-    const a = v_cur_proj.clone().multiplyScalar(1 / n_cur);
-    const b = v_tar_proj.clone().multiplyScalar(1 / n_tar);
-    const sin = axis_w.dot(a.clone().cross(b));
-    const cos = THREE.MathUtils.clamp(a.dot(b), -1, 1);
-    let ang = Math.atan2(sin, cos);
+      const ncp = v_cur_proj.length();
+      const ntp = v_tar_proj.length();
+      if (ncp < 1e-9 || ntp < 1e-9) return;
 
-    // Damp and clamp step size
-    ang = THREE.MathUtils.clamp(ang * this.gain, -this.maxStepRad, this.maxStepRad);
+      const a = v_cur_proj.clone().multiplyScalar(1 / ncp);
+      const b = v_tar_proj.clone().multiplyScalar(1 / ntp);
+      const sin = axis_w.dot(a.clone().cross(b));
+      const cos = THREE.MathUtils.clamp(a.dot(b), -1, 1);
+      let ang = Math.atan2(sin, cos);
+      ang = THREE.MathUtils.clamp(ang * this.gain, -this.maxStepRad, this.maxStepRad);
+      delta_world = new THREE.Quaternion().setFromAxisAngle(axis_w, ang);
+    } else { // ball
+      const a = v_cur.clone().multiplyScalar(1 / n_cur);
+      const b = v_tar.clone().multiplyScalar(1 / n_tar);
+      let axis_w = a.clone().cross(b);
+      const s = axis_w.length();
+      if (s < 1e-9) return;
+      axis_w.multiplyScalar(1 / s);
+      const cos = THREE.MathUtils.clamp(a.dot(b), -1, 1);
+      let ang = Math.atan2(s, cos);
+      ang = THREE.MathUtils.clamp(ang * this.gain, -this.maxStepRad, this.maxStepRad);
+      delta_world = new THREE.Quaternion().setFromAxisAngle(axis_w, ang);
+    }
 
-    // Apply world-space delta around hinge axis, convert to joint-local
-    const delta_world = new THREE.Quaternion().setFromAxisAngle(axis_w, ang);
     const delta_local = parent_qw.clone().invert().multiply(delta_world).multiply(parent_qw);
 
     if (jIndex === 1) {
       this.q1 = delta_local.multiply(this.q1).normalize();
-      this.q1 = clampHinge(this.q1, this.axis1, this.lim1.min, this.lim1.max);
+      if (this.joint1.type === 'ball') {
+        this.q1 = clampBall(this.q1, this.axis1, this.joint1.swingX, this.joint1.swingY, this.joint1.twistMin, this.joint1.twistMax);
+      } else {
+        this.q1 = clampHinge(this.q1, this.axis1, this.lim1.min, this.lim1.max);
+      }
     } else {
       this.q0 = delta_local.multiply(this.q0).normalize();
-      this.q0 = clampHinge(this.q0, this.axis0, this.lim0.min, this.lim0.max);
+      if (this.joint0.type === 'ball') {
+        this.q0 = clampBall(this.q0, this.axis0, this.joint0.swingX, this.joint0.swingY, this.joint0.twistMin, this.joint0.twistMax);
+      } else {
+        this.q0 = clampHinge(this.q0, this.axis0, this.lim0.min, this.lim0.max);
+      }
     }
   }
 
   iterate(target) {
     // End → root
-    this.rotateJointAboutHinge(1, target); // elbow
-    this.rotateJointAboutHinge(0, target); // shoulder
+    this.rotateJoint(1, target); // elbow
+    this.rotateJoint(0, target); // shoulder
   }
 
   solve(target, { maxIters = 120, tol = 1e-2 } = {}) {

--- a/ik/test/ccd2.spec.js
+++ b/ik/test/ccd2.spec.js
@@ -1,6 +1,7 @@
 const THREE = require('three');
 const fc = require('fast-check');
 const { TwoBoneChain } = require('../src/solvers/ccd2');
+const { swingTwistDecomposition, basisFromAxis } = require('../src/math/ik_constraints');
 
 describe('TwoBoneChain CCD with hinge constraints', () => {
   it('solves random truly-reachable planar targets (respecting both elbow and shoulder limits)', () => {
@@ -69,5 +70,88 @@ describe('TwoBoneChain CCD with hinge constraints', () => {
 
     const res = chain.solve(p2, { maxIters: 200, tol: 1e-2 });
     expect(res.err).toBeLessThan(1e-2);
+  });
+
+  it('clamps to hinge limits for unreachable targets', () => {
+    const L1 = 1.0, L2 = 0.7;
+    const chain = new TwoBoneChain(L1, L2, {
+      axis0: new THREE.Vector3(0,0,1),
+      axis1: new THREE.Vector3(0,0,1),
+      lim0: { min: -Math.PI/4, max: Math.PI/4 },
+      lim1: { min: 0, max: Math.PI*0.95 }
+    });
+
+    // Target requires shoulder rotation beyond max limit
+    const phi = 0.5;
+    const theta = Math.PI/2; // beyond shoulder limit
+    chain.q0.setFromAxisAngle(chain.axis0, theta);
+    chain.q1.setFromAxisAngle(chain.axis1, phi);
+    const { p2 } = chain.fk();
+
+    chain.q0.set(0,0,0,1);
+    chain.q1.set(0,0,0,1);
+
+    const res = chain.solve(p2, { maxIters: 200, tol: 1e-2 });
+    expect(res.err).toBeGreaterThan(1e-2);
+    const { twist } = swingTwistDecomposition(chain.q0, chain.axis0);
+    const tvec = new THREE.Vector3(twist.x, twist.y, twist.z);
+    const ang = 2 * Math.atan2(tvec.dot(chain.axis0), twist.w);
+    expect(Math.abs(ang - chain.lim0.max)).toBeLessThan(1e-3);
+  });
+});
+
+describe('TwoBoneChain CCD with ball constraints', () => {
+  it('solves targets within ball joint limits', () => {
+    const L1 = 1.0, L2 = 0.7;
+    const chain = new TwoBoneChain(L1, L2, {
+      joint0: { type: 'ball', axis: new THREE.Vector3(0,0,1), swingX: Math.PI/4, swingY: Math.PI/4, twistMin: -Math.PI/8, twistMax: Math.PI/8 },
+      axis1: new THREE.Vector3(0,0,1),
+      lim1: { min: 0, max: Math.PI*0.95 }
+    });
+
+    const swing = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0,1,0), 0.2);
+    const twist = new THREE.Quaternion().setFromAxisAngle(chain.axis0, 0.1);
+    chain.q0 = swing.multiply(twist);
+    const phi = 0.5;
+    chain.q1.setFromAxisAngle(chain.axis1, phi);
+    const { p2 } = chain.fk();
+
+    chain.q0.set(0,0,0,1);
+    chain.q1.set(0,0,0,1);
+
+    const res = chain.solve(p2, { maxIters: 200, tol: 1e-2 });
+    expect(res.err).toBeLessThan(1e-2);
+  });
+
+  it('clamps swing beyond ball limits', () => {
+    const L1 = 1.0, L2 = 0.7;
+    const swingY = Math.PI/6;
+    const chain = new TwoBoneChain(L1, L2, {
+      joint0: { type: 'ball', axis: new THREE.Vector3(0,0,1), swingX: Math.PI/4, swingY, twistMin: -Math.PI/8, twistMax: Math.PI/8 },
+      axis1: new THREE.Vector3(0,0,1),
+      lim1: { min: 0, max: Math.PI*0.95 }
+    });
+
+    const swing = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0,1,0), swingY*2); // beyond limit
+    chain.q0 = swing;
+    const phi = 0.5;
+    chain.q1.setFromAxisAngle(chain.axis1, phi);
+    const { p2 } = chain.fk();
+
+    chain.q0.set(0,0,0,1);
+    chain.q1.set(0,0,0,1);
+
+    const res = chain.solve(p2, { maxIters: 200, tol: 1e-2 });
+    expect(res.err).toBeGreaterThan(1e-2);
+    const { swing: sw } = swingTwistDecomposition(chain.q0, chain.axis0);
+    const swv = new THREE.Vector3(sw.x, sw.y, sw.z);
+    const ang = 2 * Math.atan2(swv.length(), sw.w);
+    let sy = 0;
+    if (ang > 1e-8) {
+      const swingAxis = swv.clone().normalize();
+      const { e2 } = basisFromAxis(chain.axis0); // e2 aligns with +Y for axis Z
+      sy = ang * swingAxis.dot(e2); // component along Y
+    }
+    expect(Math.abs(sy) - swingY).toBeLessThan(1e-3);
   });
 });


### PR DESCRIPTION
## Summary
- Allow TwoBoneChain to accept hinge or ball joint constraints with swing/twist limits
- Invoke `clampBall` for ball joints during warm start and iteration
- Test CCD solver with hinge and ball constraints for in-range and out-of-range targets

## Testing
- `cd ik && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a5ff69e144832bbef53e9c39820225