### PR TITLE
Initialize rotation limit dialog before loading data

### DIFF
--- a/js/animations/rotation_limit_dialog.js
+++ b/js/animations/rotation_limit_dialog.js
@@ -65,7 +65,7 @@ var RotationLimitDialog = new Dialog({
 RotationLimitDialog.open = function(clicked_group) {
     let groups = Group.all.filter(g => g.selected);
     if (!groups.length) groups = [clicked_group];
-    this.content_vue.load(groups);
     this.show();
+    this.content_vue.load(groups);
 };
 


### PR DESCRIPTION
## Summary
- Ensure IK rotation limit dialog builds its content before populating data

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a6e5aa2c6c832bb0bf66dd24d2ed8f