### PR TITLE
Fix rotation limit dialog initialization

### DIFF
--- a/js/animations/rotation_limit_dialog.js
+++ b/js/animations/rotation_limit_dialog.js
@@ -1,3 +1,5 @@
+const Vue = globalThis.Vue || require('vue');
+
 var RotationLimitDialog = new Dialog({
     id: 'ik_limits_editor',
     title: 'IK Rotation Limits',
@@ -64,8 +66,9 @@ var RotationLimitDialog = new Dialog({
 
 RotationLimitDialog.open = function(clicked_group) {
     let groups = Group.all.filter(g => g.selected);
-    if (!groups.length) groups = [clicked_group];
+    if (!groups.length && clicked_group) groups = [clicked_group];
+    if (!this.content_vue) this.build();
+    Vue.nextTick(() => this.content_vue.load(groups));
     this.show();
-    this.content_vue.load(groups);
 };
 


### PR DESCRIPTION
## Summary
- Ensure rotation limit dialog builds its Vue component when needed
- Load selected groups after Vue mounts and guard against missing clicked group
- Import Vue so `nextTick` is available

## Testing
- `node --check js/animations/rotation_limit_dialog.js`
- `node - <<'NODE'
const fs = require('fs');
const VueLib = require('vue');
global.Vue = VueLib;
global.Dialog = class{constructor(o){Object.assign(this,o);}build(){this.content_vue={load(){console.log('load called')}};} show(){console.log('show');}};
global.Group = {all:[]};
const vm = require('vm');
vm.runInThisContext(fs.readFileSync('./js/animations/rotation_limit_dialog.js', 'utf8'));
Group.all = [{selected:true, uuid:'a'}];
RotationLimitDialog.open();
setTimeout(()=>{},0);
NODE`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a6f11e6670832b96e619bd1c2b8368