### PR TITLE
Add rotation limit bone selection checks

### DIFF
--- a/js/animations/rotation_limit_dialog.js
+++ b/js/animations/rotation_limit_dialog.js
@@ -14,6 +14,12 @@ var RotationLimitDialog = new Dialog({
         },
         methods: {
             load(groups) {
+                groups = (groups || []).filter(g => g instanceof Group);
+                if (!groups.length) {
+                    Blockbench.showMessageBox({title:'Select a bone', message:'Please select a bone to edit rotation limits.'});
+                    RotationLimitDialog.hide();
+                    return;
+                }
                 this.groups = groups;
                 this.values = {};
                 groups.forEach(g => {
@@ -67,6 +73,10 @@ var RotationLimitDialog = new Dialog({
 RotationLimitDialog.open = function(clicked_group) {
     let groups = Group.all.filter(g => g.selected);
     if (!groups.length && clicked_group) groups = [clicked_group];
+    if (!groups.length) {
+        Blockbench.showMessageBox({title:'Select a bone', message:'Please select a bone to edit rotation limits.'});
+        return;
+    }
     if (!this.content_vue) this.build();
     Vue.nextTick(() => this.content_vue.load(groups));
     this.show();


### PR DESCRIPTION
## Summary
- ensure rotation limit dialog only opens when a bone is selected
- filter and validate groups before loading rotation limit data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a6f26261d4832b81df5797be47fe2f