### PR TITLE
Allow full 180° hinge motion

### DIFF
--- a/ik/src/solvers/ccd2.js
+++ b/ik/src/solvers/ccd2.js
@@ -63,7 +63,7 @@ class TwoBoneChain {
 
     // Step tuning
     this.gain = 0.6;                   // damp each step to avoid overshoot near limits
-    this.maxStepRad = Math.PI / 10;    // max ~18 degrees per iteration
+    this.maxStepRad = Math.PI;         // allow up to 180 degrees per iteration
   }
 
   // Forward kinematics

--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -764,17 +764,6 @@ class NullObjectAnimator extends BoneAnimator {
                                        const min = THREE.MathUtils.degToRad(Math.min(minArr[keep], maxArr[keep]));
                                        const max = THREE.MathUtils.degToRad(Math.max(minArr[keep], maxArr[keep]));
 
-                                       // (Optional) small step cap about hinge axis to calm edges
-                                       const maxStep = Math.PI / 10; // ~18°
-                                       {
-                                               const axis = axisLocal;
-                                               const v = new THREE.Vector3(Reusable.quat1.x, Reusable.quat1.y, Reusable.quat1.z);
-                                               const signed = 2 * Math.atan2(v.dot(axis), Reusable.quat1.w);
-                                               const limited = THREE.MathUtils.clamp(signed, -maxStep, maxStep);
-                                               Reusable.quat1.setFromAxisAngle(axis, limited);
-                                               q_new_unclamped = Reusable.quat1.clone().multiply(q_local).normalize();
-                                       }
-
                                        // Project ABSOLUTE local pose to hinge limits (like the harness)
                                        q_new = IKConstraints.clampHinge(q_new_unclamped, axisLocal, min, max);
                                } else {


### PR DESCRIPTION
## Summary
- Remove hinge animator step cap so constrained bones can rotate without per-frame limits
- Allow CCD solver to take up to 180° per iteration for faster convergence

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run bundle`

------
https://chatgpt.com/codex/tasks/task_b_68a703337424832bbccd96fb6c2955bb