### PR TITLE
Respect rotation_pole_enabled when generating hinge-lock poles

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -677,7 +677,7 @@ class NullObjectAnimator extends BoneAnimator {
 
                let pole_locators = {};
                bones.forEach(bone => {
-                       if (bone.rotation_hinge_lock) {
+                       if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
                                let pole = bone.rotation_pole_uuid && PoleVector.all.find(l => l.uuid === bone.rotation_pole_uuid);
                                if (!pole) {
                                        pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
@@ -692,7 +692,9 @@ class NullObjectAnimator extends BoneAnimator {
                                        bone.rotation_pole_uuid = pole.uuid;
                                        pole.select();
                                }
-                               pole_locators[bone.uuid] = pole;
+                               if (pole) {
+                                       pole_locators[bone.uuid] = pole;
+                               }
                        }
                });
 

--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -604,6 +604,7 @@ new Property(Group, 'vector', 'rotation_limit_min', {default() { return [-180, -
 new Property(Group, 'vector', 'rotation_limit_max', {default() { return [180, 180, 180]; }});
 new Property(Group, 'boolean', 'rotation_hinge_lock', {default: false});
 new Property(Group, 'number', 'rotation_hinge_axis', {default: 0});
+new Property(Group, 'boolean', 'rotation_pole_enabled', {default: true});
 new Property(Group, 'string', 'rotation_pole_uuid');
 
 Blockbench.on('load_project', () => {


### PR DESCRIPTION
## Summary
- avoid creating duplicate PoleVector objects by checking `rotation_pole_enabled`
- add `rotation_pole_enabled` property to groups

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a7164e46b8832b80f541d7d0d246da