### PR TITLE
Hide pole vector when hinge lock or pole disabled

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -677,8 +677,8 @@ class NullObjectAnimator extends BoneAnimator {
 
                let pole_locators = {};
                bones.forEach(bone => {
-                       if (bone.rotation_hinge_lock) {
-                               let pole = bone.rotation_pole_uuid && PoleVector.all.find(l => l.uuid === bone.rotation_pole_uuid);
+                       let pole = bone.rotation_pole_uuid && PoleVector.all.find(l => l.uuid === bone.rotation_pole_uuid);
+                       if (bone.rotation_hinge_lock && bone.rotation_pole_enabled !== false) {
                                if (!pole) {
                                        pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
                                        pole.createUniqueName();
@@ -691,8 +691,15 @@ class NullObjectAnimator extends BoneAnimator {
                                        pole.preview_controller.updateTransform(pole);
                                        bone.rotation_pole_uuid = pole.uuid;
                                        pole.select();
+                               } else {
+                                       pole.visibility = true;
+                                       pole.preview_controller.updateVisibility(pole);
                                }
                                pole_locators[bone.uuid] = pole;
+                       } else if (pole) {
+                               pole.visibility = false;
+                               pole.preview_controller.updateVisibility(pole);
+                               bone.rotation_pole_uuid = undefined;
                        }
                });
 

--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -93,8 +93,16 @@ PoleVector.prototype.menu = new Menu([
             const poles = PoleVector.selected.length ? PoleVector.selected.slice() : [clicked];
             Undo.initEdit({elements: poles});
             poles.forEach(p => {
+                const bone = Group.all.find(g => g.rotation_pole_uuid === p.uuid);
+                if (bone && bone.rotation_pole_enabled === false) return;
                 p.visibility = false;
                 p.preview_controller.updateVisibility(p);
+                if (bone) {
+                    bone.rotation_pole_enabled = false;
+                    if (!bone.rotation_hinge_lock) {
+                        bone.rotation_pole_uuid = undefined;
+                    }
+                }
             });
             Undo.finishEdit('Hide pole vector');
             if (Modes.animate && !this._runningPreview) {
@@ -113,7 +121,7 @@ PoleVector.prototype.menu = new Menu([
             Undo.initEdit({elements: poles});
             poles.forEach(p => {
                 const bone = Group.all.find(g => g.rotation_pole_uuid === p.uuid);
-                if (bone && bone.mesh) {
+                if (bone && bone.rotation_pole_enabled !== false && bone.mesh) {
                     const pos = bone.mesh.getWorldPosition(new THREE.Vector3());
                     if (p.parent && p.parent.mesh) p.parent.mesh.worldToLocal(pos);
                     p.position.V3_set(pos);


### PR DESCRIPTION
## Summary
- Clear pole vector and hide mesh when hinge lock is off or pole disabled
- Update pole vector menu to honor rotation_pole_enabled and break association when hiding

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a71662a5cc832b8e92225ed030c7fa