### PR TITLE
Allow pole vectors to remain under NullObject parents

### DIFF
--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -63,7 +63,7 @@ class PoleVector extends OutlinerElement {
         return pos;
     }
     init() {
-        if (this.parent instanceof Group == false) {
+        if (!(this.parent instanceof Group) && !(this.parent instanceof NullObject)) {
             this.addTo(Group.first_selected);
         }
         super.init();


### PR DESCRIPTION
## Summary
- Permit pole vectors to retain selected `NullObject` parents during initialization.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a774a539e8832ba22f1caac6244aef