### PR TITLE
Fix IK pole vector lookup and cleanup

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -675,34 +675,45 @@ class NullObjectAnimator extends BoneAnimator {
 		if (!bones.length) return;
 		bones.reverse();
 
-               let pole_locators = {};
-              bones.forEach(bone => {
-                      let pole = bone.rotation_pole_uuid &&
-                              PoleVector.all.find(l => l.uuid === bone.rotation_pole_uuid);
-                      if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
-                              if (!pole) {
-                                      pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
-                                      pole.createUniqueName();
-                                      const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
-                                      const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
-                                      const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
-                                       const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
-                                       null_object.mesh.worldToLocal(posWorld);
-                                       pole.position.V3_set(posWorld);
-                                       pole.preview_controller.updateTransform(pole);
-                                       bone.rotation_pole_uuid = pole.uuid;
-                                       pole.select();
-                               } else {
-                                       pole.visibility = true;
-                                       pole.preview_controller.updateVisibility(pole);
-                               }
-                               pole_locators[bone.uuid] = pole;
-                      } else if (pole) {
-                              pole.visibility = false;
-                              pole.preview_controller.updateVisibility(pole);
-                              bone.rotation_pole_uuid = undefined;
-                      }
-              });
+             let pole_locators = {};
+             bones.forEach(bone => {
+                     let pole = bone.rotation_pole_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_uuid);
+                     if (!(pole instanceof PoleVector)) pole = undefined;
+
+                     if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
+                             if (!pole) {
+                                     pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
+                                     pole.createUniqueName();
+                                     const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
+                                     const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
+                                     const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
+                                     const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
+                                     null_object.mesh.worldToLocal(posWorld);
+                                     pole.position.V3_set(posWorld);
+                                     pole.preview_controller.updateTransform(pole);
+                                     bone.rotation_pole_uuid = pole.uuid;
+                                     pole.select();
+                             } else {
+                                    if (pole.parent !== null_object.parent) pole.addTo(null_object);
+                                     pole.visibility = true;
+                                     pole.preview_controller.updateVisibility(pole);
+                             }
+                             pole_locators[bone.uuid] = pole;
+                     } else if (pole) {
+                             pole.visibility = false;
+                             pole.preview_controller.updateVisibility(pole);
+                             bone.rotation_pole_uuid = undefined;
+                     }
+             });
+
+             // Cleanup unreferenced pole vectors
+             const used_poles = new Set(Object.values(pole_locators).map(p => p.uuid));
+             const parent_array = null_object.parent === 'root' ? Outliner.root : null_object.parent.children;
+             parent_array.slice().forEach(child => {
+                     if (child instanceof PoleVector && !used_poles.has(child.uuid) && !Group.all.find(g => g.rotation_pole_uuid === child.uuid)) {
+                             child.remove();
+                     }
+             });
 
                let base_rotations = {};
                bones.forEach(bone => {


### PR DESCRIPTION
## Summary
- Recursively search for existing pole vectors under bones in `displayIK`
- Reparent found pole vectors and update visibility instead of always creating new ones
- Remove unused pole vectors to prevent stale helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a77a74178c832bbb61687ef4bb6f00