### PR TITLE
Avoid pole vector reset during IK preview

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -680,30 +680,32 @@ class NullObjectAnimator extends BoneAnimator {
                      let pole = bone.rotation_pole_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_uuid);
                      if (!(pole instanceof PoleVector)) pole = undefined;
 
-                     if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
-                             if (!pole) {
-                                     pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
-                                     pole.createUniqueName();
-                                     const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
-                                     const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
-                                     const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
-                                     const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
-                                     null_object.mesh.worldToLocal(posWorld);
-                                     pole.position.V3_set(posWorld);
-                                     pole.preview_controller.updateTransform(pole);
-                                     bone.rotation_pole_uuid = pole.uuid;
-                                     pole.select();
-                             } else {
-                                    if (pole.parent !== null_object.parent) pole.addTo(null_object);
-                                     pole.visibility = true;
-                                     pole.preview_controller.updateVisibility(pole);
-                             }
-                             pole_locators[bone.uuid] = pole;
-                     } else if (pole) {
-                             pole.visibility = false;
-                             pole.preview_controller.updateVisibility(pole);
-                             bone.rotation_pole_uuid = undefined;
-                     }
+                    if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
+                            if (!pole) {
+                                    pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
+                                    pole.createUniqueName();
+                                    const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
+                                    const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
+                                    const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
+                                    const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
+                                    null_object.mesh.worldToLocal(posWorld);
+                                    pole.position.V3_set(posWorld);
+                                    pole.preview_controller.updateTransform(pole);
+                                    bone.rotation_pole_uuid = pole.uuid;
+                                    pole.select();
+                            } else if (pole._ik_moved) {
+                                    pole.preview_controller.updateTransform(pole);
+                                    pole._ik_moved = false;
+                            }
+                            if (pole.parent !== null_object.parent) pole.addTo(null_object);
+                            pole.visibility = true;
+                            pole.preview_controller.updateVisibility(pole);
+                            pole_locators[bone.uuid] = pole;
+                    } else if (pole) {
+                            pole.visibility = false;
+                            pole.preview_controller.updateVisibility(pole);
+                            bone.rotation_pole_uuid = undefined;
+                    }
              });
 
              // Cleanup unreferenced pole vectors

--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -210,3 +210,8 @@ OutlinerElement.registerType(PoleVector, 'pole_vector');
         }
     });
 })();
+
+PoleVector.on('moved', function() {
+    this._ik_moved = true;
+    Animator.preview();
+});


### PR DESCRIPTION
## Summary
- Only position new pole vectors once and update existing poles only when they've moved
- Trigger IK preview when a pole vector is moved so orientation updates without snapping back

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a77bf053d4832ba9edba1d335e8adc