### PR TITLE
Assign null object animator to pole vectors

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -945,14 +945,15 @@ class NullObjectAnimator extends BoneAnimator {
 }
 NullObjectAnimator.prototype.type = 'null_object';
 NullObjectAnimator.prototype.channels = {
-	position: { name: tl('timeline.position'), mutable: true, transform: true, max_data_points: 2 },
+        position: { name: tl('timeline.position'), mutable: true, transform: true, max_data_points: 2 },
 }
 NullObject.animator = NullObjectAnimator;
+PoleVector.animator = NullObjectAnimator;
 
 class EffectAnimator extends GeneralAnimator {
-	constructor(animation) {
-		super(null, animation);
-		this.last_displayed_time = 0;
+        constructor(animation) {
+                super(null, animation);
+                this.last_displayed_time = 0;
 
 		this.name = tl('timeline.effects')
 		this.selected = false;


### PR DESCRIPTION
## Summary
- Allow pole vectors to use the null object animator so their position can be keyed on the timeline.
- Verified pole vector implementation doesn't override selection in Animate mode.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run bundle`


------
https://chatgpt.com/codex/tasks/task_b_68a77fc071d0832bb80817b3da26a9b9