### PR TITLE
Preserve pole vector parenting during IK previews

### DIFF
--- a/js/animations/rotation_limit_dialog.js
+++ b/js/animations/rotation_limit_dialog.js
@@ -56,6 +56,7 @@ var RotationLimitDialog = new Dialog({
                         const pole_parent = g.parent instanceof Group ? g.parent : g;
                         let pole = new PoleVector({name: g.name + '_pole'}).addTo(pole_parent).init();
                         pole.createUniqueName();
+                        g.rotation_pole_parent_uuid = pole.parent.uuid;
                         const axisVec = axis === 0 ? new THREE.Vector3(1,0,0) : axis === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
                         const axisWorld = axisVec.clone().applyQuaternion(g.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
                         const posWorld = g.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));

--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -681,23 +681,30 @@ class NullObjectAnimator extends BoneAnimator {
                      if (!(pole instanceof PoleVector)) pole = undefined;
 
                     if (bone.rotation_hinge_lock && bone.rotation_pole_enabled) {
-                            if (!pole) {
-                                    pole = new PoleVector({name: bone.name + '_pole'}).addTo(null_object).init();
-                                    pole.createUniqueName();
-                                    const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
-                                    const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
-                                    const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
-                                    const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
-                                    null_object.mesh.worldToLocal(posWorld);
-                                    pole.position.V3_set(posWorld);
-                                    pole.preview_controller.updateTransform(pole);
-                                    bone.rotation_pole_uuid = pole.uuid;
-                                    pole.select();
-                            } else if (pole._ik_moved) {
-                                    pole.preview_controller.updateTransform(pole);
-                                    pole._ik_moved = false;
-                            }
-                            if (pole.parent !== null_object.parent) pole.addTo(null_object);
+				if (!pole) {
+					const pole_parent = (
+						bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
+					) || bone.parent;
+					pole = new PoleVector({name: bone.name + '_pole'}).addTo(pole_parent).init();
+					pole.createUniqueName();
+					const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
+					const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
+					const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
+					const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
+					if (pole.parent && pole.parent.mesh) pole.parent.mesh.worldToLocal(posWorld);
+					pole.position.V3_set(posWorld);
+					pole.preview_controller.updateTransform(pole);
+					bone.rotation_pole_uuid = pole.uuid;
+					pole.select();
+				} else if (pole._ik_moved) {
+					pole.preview_controller.updateTransform(pole);
+					pole._ik_moved = false;
+				} else if (!pole.parent) {
+					const pole_parent = (
+						bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
+					) || bone.parent;
+					pole.addTo(pole_parent);
+				}
                             pole.visibility = true;
                             pole.preview_controller.updateVisibility(pole);
                             pole_locators[bone.uuid] = pole;

--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -70,6 +70,15 @@ class PoleVector extends OutlinerElement {
         return this;
     }
 }
+
+PoleVector.prototype.addTo = function(parent, index) {
+    OutlinerElement.prototype.addTo.call(this, parent, index);
+    const bone = Group.all.find(g => g.rotation_pole_uuid === this.uuid);
+    if (bone) {
+        bone.rotation_pole_parent_uuid = this.parent && this.parent.uuid;
+    }
+    return this;
+};
 PoleVector.prototype.title = 'Pole Vector';
 PoleVector.prototype.type = 'pole_vector';
 PoleVector.prototype.icon = 'fa-bullseye';


### PR DESCRIPTION
## Summary
- honor stored pole vector parent during IK displays and only reparent when missing
- record pole vector parent when enabling and when reparented

## Testing
- `node --check js/animations/timeline_animators.js`
- `node --check js/animations/rotation_limit_dialog.js`
- `node --check js/outliner/pole_vector.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a783eb0a40832b8688c03fca612bbb