### PR TITLE
Fix pole vector line direction and orientation

### DIFF
--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -187,13 +187,11 @@ OutlinerElement.registerType(PoleVector, 'pole_vector');
                 if (bone && bone.mesh) {
                     const pole_pos = element.mesh.getWorldPosition(new THREE.Vector3());
                     const bone_pos = bone.mesh.getWorldPosition(new THREE.Vector3());
-                    const rel = bone_pos.sub(pole_pos);
-                    line.geometry.setFromPoints([rel, new THREE.Vector3(0, 0, 0)]);
+                    const to_joint = bone_pos.clone().sub(pole_pos);
+                    line.geometry.setFromPoints([new THREE.Vector3(0, 0, 0), to_joint]);
 
                     const dir = pole_pos.clone().sub(bone_pos).normalize();
-                    element.mesh.quaternion.setFromUnitVectors(
-                        new THREE.Vector3(0, 1, 0), dir
-                    );
+                    element.mesh.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir);
                 } else {
                     line.geometry.setFromPoints([new THREE.Vector3(), new THREE.Vector3()]);
                     element.mesh.quaternion.identity();


### PR DESCRIPTION
## Summary
- avoid mutating bone position when calculating pole vector
- draw pole vector line from pole to joint
- orient cone away from joint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node test/rotation_limits.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a787551184832b9f086a753a151835