### PR TITLE
Fix IK effector length calculation

### DIFF
--- a/js/animations/ik_test_runner.js
+++ b/js/animations/ik_test_runner.js
@@ -200,7 +200,12 @@ async function runCubeSweepAsync({ anim, nullObj, center, halfSpan = 0.6, steps 
               const start = targetNode.mesh.getWorldPosition(new THREE.Vector3());
               const dir = new THREE.Vector3(0, -1, 0)
                 .applyQuaternion(targetNode.mesh.getWorldQuaternion(new THREE.Quaternion()));
-              effPos = start.clone().add(dir);
+              const length =
+                targetNode.children?.find(ch => ch.mesh)
+                  ? targetNode.children.find(ch => ch.mesh)
+                      .mesh.getWorldPosition(new THREE.Vector3()).distanceTo(start)
+                  : (targetNode.rotation_distance || 1);
+              effPos = start.clone().add(dir.multiplyScalar(length));
             }
           }
         }


### PR DESCRIPTION
## Summary
- compute bone length from child or rotation distance
- scale effector direction by bone length when estimating target position

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_b_68a853ac49e4832b838158019d736627