### PR TITLE
Skip pre-rotation when mesh missing

### DIFF
--- a/js/animations/animation_mode.js
+++ b/js/animations/animation_mode.js
@@ -295,14 +295,14 @@ const Animator = {
 				}
 				let multiplier = animation.blend_weight ? Math.clamp(Animator.MolangParser.parse(animation.blend_weight), 0, Infinity) : 1;
 				if (typeof controller_blend_values[animation.uuid] == 'number') multiplier *= controller_blend_values[animation.uuid];
-				if (anim_i == animations.length - 1) {
-					let mesh = node.mesh;
-					if (!mesh.pre_rotation) mesh.pre_rotation = new THREE.Euler();
-					mesh.pre_rotation.copy(mesh.rotation);
-				}
-				animation.getBoneAnimator(node).displayFrame(multiplier);
-			})
-		})
+                                const mesh = node.mesh;
+                                if (anim_i === animations.length - 1 && mesh) {
+                                        if (!mesh.pre_rotation) mesh.pre_rotation = new THREE.Euler();
+                                        mesh.pre_rotation.copy(mesh.rotation);
+                                }
+                                animation.getBoneAnimator(node).displayFrame(multiplier);
+                        })
+                })
 
 		Animator.resetLastValues();
 		scene.updateMatrixWorld();


### PR DESCRIPTION
## Summary
- Avoid errors in `stackAnimations` when nodes lack a mesh by verifying mesh presence before setting pre-rotation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8609e59a4832b9dcb55f32062d061