### PR TITLE
Scan entire project for unused pole vectors

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -723,14 +723,14 @@ class NullObjectAnimator extends BoneAnimator {
                     }
              });
 
-             // Cleanup unreferenced pole vectors
-             const used_poles = new Set(Object.values(pole_locators).map(p => p.uuid));
-             const parent_array = null_object.parent === 'root' ? Outliner.root : null_object.parent.children;
-             parent_array.slice().forEach(child => {
-                     if (child instanceof PoleVector && !used_poles.has(child.uuid) && !Group.all.find(g => g.rotation_pole_uuid === child.uuid)) {
-                             child.remove();
-                     }
-             });
+            // Cleanup unreferenced pole vectors
+            const used = new Set(Object.values(pole_locators).map(p => p.uuid));
+            PoleVector.all.slice().forEach(p => {
+                    if (!used.has(p.uuid) &&
+                        !Group.all.some(g => g.rotation_pole_uuid === p.uuid)) {
+                            p.remove();
+                    }
+            });
 
                let base_rotations = {};
                bones.forEach(bone => {


### PR DESCRIPTION
## Summary
- Improve pole vector cleanup during IK runs by iterating over all pole vectors and removing those not referenced by bones or groups

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8621848c4832bacd7bf79dec5c2bd