### PR TITLE
Use world-to-local conversion for global move

### DIFF
--- a/js/modeling/transform_gizmo.js
+++ b/js/modeling/transform_gizmo.js
@@ -1530,25 +1530,22 @@
 							scope.keyframes[0].offset('y', Math.trimDeg( (-Math.radToDeg(mesh.rotation.y - old_rotation.y)) - scope.keyframes[0].calc('y') ));
 							scope.keyframes[0].offset('z', Math.trimDeg( ( Math.radToDeg(mesh.rotation.z - old_rotation.z)) - scope.keyframes[0].calc('z') ));
 	
-						} else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'global') {
+							 } else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'global') {
 
-						       let offset_vec = new THREE.Vector3();
-						       offset_vec[axis] = difference;
-						       if (mesh.parent) {
-						               const parent_rot = new THREE.Matrix4();
-						               parent_rot.extractRotation(mesh.parent.matrixWorld);
-						               parent_rot.invert();
-						               offset_vec.applyMatrix4(parent_rot);
-						       }
-						      const scale = mesh.parent?.scale || new THREE.Vector3(1,1,1);
-						      offset_vec.divide(scale);            // neutralize parent scaling
-						      offset_vec.multiplyScalar(canvasGridSize(event.shiftKey || Pressing.overrides.shift, event.ctrlOrCmd || Pressing.overrides.ctrl));
+								const delta = new THREE.Vector3();
+								delta[axis] = difference;
+								const worldTarget = mesh.getWorldPosition(new THREE.Vector3()).add(delta);
+								const localTarget = mesh.parent
+									? mesh.parent.worldToLocal(worldTarget)
+									: worldTarget;
+								const offset_vec = localTarget.sub(mesh.position)
+									.divide(mesh.parent?.scale || new THREE.Vector3(1,1,1))
+									.multiplyScalar(canvasGridSize(event.shiftKey || Pressing.overrides.shift, event.ctrlOrCmd || Pressing.overrides.ctrl));
+								scope.keyframes[0].offset('x', -offset_vec.x);
+								scope.keyframes[0].offset('y',  offset_vec.y);
+								scope.keyframes[0].offset('z',  offset_vec.z);
 
-						      scope.keyframes[0].offset('x', -offset_vec.x);
-						      scope.keyframes[0].offset('y', offset_vec.y);
-						      scope.keyframes[0].offset('z', offset_vec.z);
-
-					       } else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'local') {
+							 } else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'local') {
 
 						       let offset_vec = new THREE.Vector3();
 						       offset_vec[axis] = difference;


### PR DESCRIPTION
## Summary
- use world position to compute global move offsets with world-to-local conversion

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*

------
https://chatgpt.com/codex/tasks/task_b_68a87dd27aa8832ba6037da1a6fe292e