### PR TITLE
Fix pole vector offset for global gizmo moves

### DIFF
--- a/js/modeling/transform_gizmo.js
+++ b/js/modeling/transform_gizmo.js
@@ -1535,15 +1535,15 @@
 								const delta = new THREE.Vector3();
 								delta[axis] = difference;
 								const worldTarget = mesh.getWorldPosition(new THREE.Vector3()).add(delta);
-								const localTarget = mesh.parent
-									? mesh.parent.worldToLocal(worldTarget)
-									: worldTarget;
-								const offset_vec = localTarget.sub(mesh.position)
-									.divide(mesh.parent?.scale || new THREE.Vector3(1,1,1))
-									.multiplyScalar(canvasGridSize(event.shiftKey || Pressing.overrides.shift, event.ctrlOrCmd || Pressing.overrides.ctrl));
-								scope.keyframes[0].offset('x', -offset_vec.x);
-								scope.keyframes[0].offset('y',  offset_vec.y);
-								scope.keyframes[0].offset('z',  offset_vec.z);
+                                                                const localTarget = mesh.parent
+                                                                        ? mesh.parent.worldToLocal(worldTarget)
+                                                                        : worldTarget;
+                                                                const offset_vec = localTarget.sub(Reusable.vec3.fromArray(Outliner.selected[0].position))
+                                                                        .divide(mesh.parent?.scale || new THREE.Vector3(1,1,1))
+                                                                        .multiplyScalar(canvasGridSize(event.shiftKey || Pressing.overrides.shift, event.ctrlOrCmd || Pressing.overrides.ctrl));
+                                                                scope.keyframes[0].offset('x', -offset_vec.x);
+                                                                scope.keyframes[0].offset('y',  offset_vec.y);
+                                                                scope.keyframes[0].offset('z',  offset_vec.z);
 
 							 } else if (Toolbox.selected.id === 'move_tool' && BarItems.transform_space.value === 'local') {
 


### PR DESCRIPTION
## Summary
- use element position instead of mesh position when calculating global move offsets
- preserve parent scale division and keyframe offsets

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a89216c79c832b9a9e16468d367fb6