### PR TITLE
Add auto-reset option for rotation pole vectors

### DIFF
--- a/js/animations/rotation_limit_dialog.js
+++ b/js/animations/rotation_limit_dialog.js
@@ -29,7 +29,8 @@ var RotationLimitDialog = new Dialog({
                         max: Array.isArray(g.rotation_limit_max) ? g.rotation_limit_max.slice() : [180, 180, 180],
                         hinge_lock: !!g.rotation_hinge_lock,
                         hinge_axis: Math.min(2, Math.max(0, Math.floor(g.rotation_hinge_axis || 0))),
-                        pole_enabled: !!g.rotation_pole_enabled
+                        pole_enabled: !!g.rotation_pole_enabled,
+                        pole_auto_reset: !!g.rotation_pole_auto_reset
                     });
                 });
             },
@@ -49,6 +50,7 @@ var RotationLimitDialog = new Dialog({
                 g.rotation_hinge_lock = !!v.hinge_lock;
                 g.rotation_hinge_axis = axis;
                 g.rotation_pole_enabled = !!v.pole_enabled;
+                g.rotation_pole_auto_reset = !!v.pole_auto_reset;
                 Undo.finishEdit('Set IK rotation limits');
                 Canvas.updateAllBones([g]);
                 if (prevPole !== g.rotation_pole_enabled) {
@@ -89,6 +91,7 @@ var RotationLimitDialog = new Dialog({
                         <option :value="2">Z</option>
                     </select>
                     <label class="checkbox" v-if="values[g.uuid].hinge_lock"><input type="checkbox" v-model="values[g.uuid].pole_enabled" @change="apply(g)"> Pole Vector</label>
+                    <label class="checkbox" v-if="values[g.uuid].pole_enabled"><input type="checkbox" v-model="values[g.uuid].pole_auto_reset" @change="apply(g)"> Auto Reset Pole</label>
                 </div>
             </div>
         `

--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -707,12 +707,21 @@ class NullObjectAnimator extends BoneAnimator {
 				} else if (pole._ik_moved) {
 					pole.preview_controller.updateTransform(pole);
 					pole._ik_moved = false;
-				} else if (!pole.parent) {
-					const pole_parent = (
-						bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
-					) || bone.parent;
-					pole.addTo(pole_parent);
-				}
+                                } else if (!pole.parent) {
+                                        const pole_parent = (
+                                                bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
+                                        ) || bone.parent;
+                                        pole.addTo(pole_parent);
+                                }
+                                if (bone.rotation_pole_auto_reset && pole && bone.mesh) {
+                                        const pos = bone.mesh.getWorldPosition(new THREE.Vector3());
+                                        if (pole.parent && pole.parent.mesh) {
+                                                pole.parent.mesh.worldToLocal(pos);
+                                                pos.divide(pole.parent.mesh.scale);
+                                        }
+                                        pole.position.V3_set(pos);
+                                        pole.preview_controller.updateTransform(pole);
+                                }
                             pole.visibility = true;
                             pole.preview_controller.updateVisibility(pole);
                             pole_locators[bone.uuid] = pole;

--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -605,6 +605,7 @@ new Property(Group, 'vector', 'rotation_limit_max', {default() { return [180, 18
 new Property(Group, 'boolean', 'rotation_hinge_lock', {default: false});
 new Property(Group, 'number', 'rotation_hinge_axis', {default: 0});
 new Property(Group, 'boolean', 'rotation_pole_enabled', {default: false});
+new Property(Group, 'boolean', 'rotation_pole_auto_reset', {default: false});
 new Property(Group, 'string', 'rotation_pole_uuid');
 
 Blockbench.on('load_project', () => {

--- a/js/outliner/pole_vector.js
+++ b/js/outliner/pole_vector.js
@@ -144,6 +144,20 @@ PoleVector.prototype.menu = new Menu([
             if (Modes.animate) Animator.preview();
         }
     },
+    {
+        id: 'toggle_pole_auto_reset',
+        name: 'Auto Reset Pole',
+        icon: 'fa-sync',
+        click(clicked) {
+            const poles = PoleVector.selected.length ? PoleVector.selected.slice() : [clicked];
+            const bones = poles.map(p => Group.all.find(g => g.rotation_pole_uuid === p.uuid)).filter(Boolean);
+            if (!bones.length) return;
+            Undo.initEdit({groups: bones});
+            bones.forEach(b => b.rotation_pole_auto_reset = !b.rotation_pole_auto_reset);
+            Undo.finishEdit('Toggle pole auto reset');
+            if (Modes.animate) Animator.preview();
+        }
+    },
     new MenuSeparator('manage'),
     'rename',
     'toggle_visibility',


### PR DESCRIPTION
## Summary
- Add `rotation_pole_auto_reset` property for bones
- Allow toggling auto-reset in rotation limits dialog and pole vector menu
- Reset pole vectors to joint each preview when auto-reset is enabled

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a898fb2d7c832b97d67d442f633f35