### PR TITLE
Fix IK toggle updates

### DIFF
--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -523,11 +523,12 @@ class Group extends OutlinerNode {
                               let value = !clicked_group.ik_enabled;
                               let affected = Group.all.filter(g => g.selected);
                               if (!affected.length) affected = [clicked_group];
-                              Undo.initEdit({elements: affected});
-                              affected.forEach(g => { g.ik_enabled = value; });
-                              Undo.finishEdit('Toggle IK mode');
-                              Canvas.updateAllBones(affected);
-                              if (Modes.animate) Animator.preview();
+				Undo.initEdit({elements: affected, keys: ['ik_enabled']});
+				affected.forEach(g => { g.ik_enabled = value; });
+				Undo.finishEdit('Toggle IK mode');
+				Outliner.vue.$forceUpdate();
+				Canvas.updateAllBones(affected);
+				if (Modes.animate) Animator.preview();
                       }
                },
               {


### PR DESCRIPTION
## Summary
- ensure IK toggle only edits `ik_enabled`
- force Outliner to refresh after IK toggle

## Testing
- `node - <<'NODE' ...` *(unit snippet verifying toggling)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8a05c581c832b8f4c50cc4d43721d