### PR TITLE
Initialize bone IK flags and streamline animator refresh

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -987,13 +987,8 @@ Object.defineProperty(Group.prototype, 'ik_enabled', {
                 }
             });
         }
-        if (Modes.animate) Animator.preview();
+        Animator.preview();
     }
-});
-// ensure existing groups use the new property
-Group.all.forEach(g => {
-    g._ik_enabled = g.ik_enabled;
-    delete g.ik_enabled;
 });
 
 class EffectAnimator extends GeneralAnimator {

--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -3,6 +3,7 @@ class Group extends OutlinerNode {
 	constructor(data, uuid) {
 		super(uuid)
 
+		this._ik_enabled = false;
 		for (var key in Group.properties) {
 			Group.properties[key].reset(this);
 		}


### PR DESCRIPTION
## Summary
- Set each Group's `_ik_enabled` flag at construction so bones track IK state explicitly
- Simplify IK toggle handling by removing legacy property cleanup and always previewing animations on change

## Testing
- ⚠️ `npm test` (script missing)
- ✅ `npm run bundle`


------
https://chatgpt.com/codex/tasks/task_b_68a8ab7e4d1c832b97bc4b7b0aaef48a