### PR TITLE
Guard group lists against undefined Project

### DIFF
--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -547,22 +547,16 @@ class Group extends OutlinerNode {
                 'delete'
 	]);
 	Object.defineProperty(Group, 'all', {
-		get() {
-			return Project.groups || [];
-		},
-		set(arr) {
-			Project.groups.replace(arr);
-		}
+		get()	{ return (typeof Project !== 'undefined' && Project.groups)	|| []; },
+		set(a) { if (typeof Project !== 'undefined') Project.groups.replace(a); }
 	})
 	Object.defineProperty(Group, 'multi_selected', {
-		get() {
-			return Project.selected_groups || []
-		},
-		set(arr) {
-			if (arr instanceof Array == false) {
+		get()	{ return (typeof Project !== 'undefined' && Project.selected_groups) || [] },
+		set(a) {
+			if (a instanceof Array == false) {
 				console.warn('Not an array!')
 			}
-			Project.selected_groups.replace(arr)
+			if (typeof Project !== 'undefined') Project.selected_groups.replace(a)
 		}
 	})
 	Object.defineProperty(Group, 'selected', {


### PR DESCRIPTION
## Summary
- Guard Group.all getter and setter when `Project` is undefined
- Apply the same guard to `Group.multi_selected` to prevent errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8b053b844832ba9fee950be2a7d14