### PR TITLE
Enable undo operations for groups

### DIFF
--- a/js/outliner/group.js
+++ b/js/outliner/group.js
@@ -443,6 +443,9 @@ class Group extends OutlinerNode {
 		this.updateElement()
 	}
 }
+	Group.prototype.getUndoCopy = function() {
+	return this.getChildlessCopy(true);
+	};
 	Group.prototype.title = tl('data.group');
 	Group.prototype.type = 'group';
 	Group.prototype.icon = 'folder';


### PR DESCRIPTION
## Summary
- allow groups to produce undo copies by exposing `getUndoCopy`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8b1da5e8c832b96dd85246a22006b