### PR TITLE
Handle null object transform when Animator is active

### DIFF
--- a/js/outliner/null_object.js
+++ b/js/outliner/null_object.js
@@ -167,17 +167,16 @@ class NullObject extends OutlinerElement {
 	
 			this.dispatchEvent('setup', {element});
 			this.dispatchEvent('update_selection', {element});
-		},
-		updateTransform(element) {
-			NodePreviewController.prototype.updateTransform.call(this, element);
-
-			element.mesh.fix_position.copy(element.mesh.position);
-
-			this.updateWindowSize(element);
-
-			this.dispatchEvent('update_transform', {element});
-		},
-		updateSelection(element) {
+},
+                updateTransform(element) {
+                        NodePreviewController.prototype.updateTransform.call(this, element);
+                        if (!Animator.open) {
+                                element.mesh.fix_position.copy(element.mesh.position);
+                        }
+                        this.updateWindowSize(element);
+                        this.dispatchEvent('update_transform', {element});
+                },
+                updateSelection(element) {
 			let {mesh} = element;
 	
 			mesh.material.color.set(element.selected ? gizmo_colors.outline : CustomTheme.data.colors.text);


### PR DESCRIPTION
## Summary
- Avoid overwriting `mesh.fix_position` while Animator is open so null object sprites stay in sync

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a8de044440832b9d24515f3028ba60