### PR TITLE
Reset bones to rest pose before IK chain

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -676,15 +676,16 @@ class NullObjectAnimator extends BoneAnimator {
 			bones.push(source);
 		}
 		if (!bones.length) return;
-		bones.reverse();
+               bones.reverse();
 
-		bones.forEach(bone => {
-			if (bone.rest_quaternion) {
-				bone.mesh.quaternion.copy(bone.rest_quaternion);
-				bone.mesh.rotation.setFromQuaternion(bone.rest_quaternion, 'ZYX');
-				bone.mesh.updateMatrixWorld();
-			}
-		});
+               bones.forEach(bone => {
+                       if (bone.mesh.fix_position) bone.mesh.position.copy(bone.mesh.fix_position);
+                       if (bone.rest_quaternion) {
+                               bone.mesh.quaternion.copy(bone.rest_quaternion);
+                               bone.mesh.rotation.setFromQuaternion(bone.rest_quaternion, 'ZYX');
+                       }
+                       bone.mesh.updateMatrixWorld();
+               });
 
              let pole_locators = {};
              bones.forEach(bone => {


### PR DESCRIPTION
## Summary
- Reset each bone's position and rotation to its stored rest pose before building the IK chain to keep limb attachments stable.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run bundle`


------
https://chatgpt.com/codex/tasks/task_b_68a8df016930832bb7bc0e51737a935c