### PR TITLE
Preserve selection when creating IK pole vector

### DIFF
--- a/js/animations/timeline_animators.js
+++ b/js/animations/timeline_animators.js
@@ -697,21 +697,22 @@ class NullObjectAnimator extends BoneAnimator {
 					const pole_parent = (
 						bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
 					) || bone.parent;
-					pole = new PoleVector({name: bone.name + '_pole'}).addTo(pole_parent).init();
-					pole.createUniqueName();
-					const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
-					const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
-					const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
-					const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
-					if (pole.parent && pole.parent.mesh) pole.parent.mesh.worldToLocal(posWorld);
-					pole.position.V3_set(posWorld);
-					pole.preview_controller.updateTransform(pole);
-					bone.rotation_pole_uuid = pole.uuid;
-					pole.select();
-				} else if (pole._ik_moved) {
-					pole.preview_controller.updateTransform(pole);
-					pole._ik_moved = false;
-                                } else if (!pole.parent) {
+                                       const prevSel = Outliner.selected.slice();
+                                       pole = new PoleVector({name: bone.name + '_pole'}).addTo(pole_parent).init();
+                                       pole.createUniqueName();
+                                       const axisIndex = Math.min(2, Math.max(0, Math.floor(bone.rotation_hinge_axis || 0)));
+                                       const axisVec = axisIndex === 0 ? new THREE.Vector3(1,0,0) : axisIndex === 1 ? new THREE.Vector3(0,1,0) : new THREE.Vector3(0,0,1);
+                                       const axisWorld = axisVec.clone().applyQuaternion(bone.mesh.getWorldQuaternion(new THREE.Quaternion())).normalize();
+                                       const posWorld = bone.mesh.getWorldPosition(new THREE.Vector3()).add(axisWorld.multiplyScalar(6));
+                                       if (pole.parent && pole.parent.mesh) pole.parent.mesh.worldToLocal(posWorld);
+                                       pole.position.V3_set(posWorld);
+                                       pole.preview_controller.updateTransform(pole);
+                                       bone.rotation_pole_uuid = pole.uuid;
+                                       prevSel.forEach(el => el.select());
+                               } else if (pole._ik_moved) {
+                                       pole.preview_controller.updateTransform(pole);
+                                       pole._ik_moved = false;
+                               } else if (!pole.parent) {
                                         const pole_parent = (
                                                 bone.rotation_pole_parent_uuid && Project.elements.findRecursive('uuid', bone.rotation_pole_parent_uuid)
                                         ) || bone.parent;


### PR DESCRIPTION
## Summary
- Preserve user selection when creating pole vectors so IK gizmos remain attached

## Testing
- `npm test` *(fails: Missing script "test" -- no tests present)*

------
https://chatgpt.com/codex/tasks/task_b_68a8e0cf51d0832bb95e62b261f397a7